### PR TITLE
Fix Firefox "Decoding failed" on GitHub Pages by bypassing Range-request cache

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -605,6 +605,27 @@
             locatorRight: $('locator-right'),
         };
 
+        // ─── Fix: Firefox Range-request caching on GitHub Pages ────────────
+        // Firefox caches HTTP 206 partial responses and incorrectly serves
+        // later Range requests from the cached fragment, breaking PMTiles
+        // tile loading and DuckDB-WASM parquet reads.  Force cache bypass
+        // for every Range request so the browser always hits the network.
+        // See https://github.com/protomaps/PMTiles/issues/584
+        (function () {
+            const _fetch = window.fetch;
+            window.fetch = function (input, init) {
+                if (init && init.headers && !init.cache) {
+                    const h = init.headers instanceof Headers
+                        ? init.headers
+                        : new Headers(init.headers);
+                    if (h.has('Range')) {
+                        return _fetch.call(this, input, Object.assign({}, init, { cache: 'no-store' }));
+                    }
+                }
+                return _fetch.call(this, input, init);
+            };
+        })();
+
         // ─── PMTiles Protocol ───────────────────────────────────────────────
         const protocol = new pmtiles.Protocol();
         maplibregl.addProtocol('pmtiles', protocol.tile);
@@ -760,7 +781,18 @@
 
             // Fetch worker script as blob to avoid cross-origin Worker restriction
             const workerResponse = await fetch(bundle.mainWorker);
-            const workerBlob = new Blob([await workerResponse.text()], { type: 'application/javascript' });
+            let workerText = await workerResponse.text();
+
+            // Inject the same Range-request cache fix into the Worker context
+            // so DuckDB-WASM parquet HTTP reads also bypass Firefox's cache.
+            const rangeFix = '(function(){var f=self.fetch;self.fetch=function(i,o){'
+                + 'if(o&&o.headers&&!o.cache){var h=o.headers instanceof Headers'
+                + '?o.headers:new Headers(o.headers);if(h.has("Range"))return'
+                + ' f.call(this,i,Object.assign({},o,{cache:"no-store"}))}'
+                + 'return f.call(this,i,o)}})();\n';
+            workerText = rangeFix + workerText;
+
+            const workerBlob = new Blob([workerText], { type: 'application/javascript' });
             const workerUrl = URL.createObjectURL(workerBlob);
             const worker = new Worker(workerUrl);
 


### PR DESCRIPTION
This PR has been directed by Claude Code

## Summary

The app fails in Firefox when hosted on GitHub Pages — the map shows no tiles ("Decoding failed") and DuckDB parquet queries break. It works fine locally on nginx because the issue is specific to how Firefox handles cached HTTP Range responses combined with GitHub Pages' `cache-control: max-age=600` header.

**Root cause:** Firefox caches the first HTTP 206 partial response (e.g. bytes 0–16383) and then incorrectly serves subsequent Range requests for *different* byte ranges from that cached fragment. The PMTiles library already works around this for Chrome (`cache: 'no-store'` on fetch), but [does not apply the fix for Firefox](<https://github.com/protomaps/PMTiles/issues/584>).

**Fix:** Override `fetch()` so that any request carrying a `Range` header uses `cache: 'no-store'`, forcing the browser to always go to the network. Applied in two places:

- **Main thread** — fixes PMTiles tile loading
- **DuckDB Web Worker** (injected into the worker script before blob creation) — fixes parquet HTTP reads

The override is safe for all browsers: it only activates on Range requests that don't already have a cache policy set, and `no-store` is what PMTiles already uses for Chrome.

## References

- [protomaps/PMTiles#584](<https://github.com/protomaps/PMTiles/issues/584>) — GitHub Pages hosting .pmtiles not always working
- [protomaps/PMTiles#272](<https://github.com/protomaps/PMTiles/issues/272>) — Range requests browser caching not working in Firefox

## Test plan

- [ ] Open the deployed site in Firefox and verify the landing map renders tiles
- [ ] Click an area and verify DuckDB query succeeds (comparison view loads)
- [ ] Verify Chrome still works as before