### PR TITLE
Fix GitHub Pages deploy by adding required environment declaration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,13 @@ jobs:
     permissions:
       pages: write
       id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: ./app        # ← your folder here
-      - uses: actions/deploy-pages@v4
+          path: ./app
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
PR by Claude fixing deploy env.

The deploy-pages@v4 action requires the job to declare environment: github-pages to link the deployment to the Pages environment. Without it the deployment fails silently.