### PR TITLE
Fix landing map to fit entire UK regardless of viewport

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -904,9 +904,9 @@
                         { id: 'labels', type: 'raster', source: 'carto-labels' },
                     ],
                 },
-                center: [-3.5, 55.5],
-                zoom: 4.8,
-                minZoom: 4.8,
+                bounds: [[-8.5, 49.8], [2.0, 61.0]],
+                fitBoundsOptions: { padding: 20 },
+                minZoom: 3,
                 maxBounds: [[-14, 47], [6, 63]],
                 attributionControl: true,
             });


### PR DESCRIPTION
## Summary

- Replace fixed `center`/`zoom` map initialization with `bounds`-based initialization so MapLibre dynamically calculates the correct zoom level to fit the full UK extent within any viewport aspect ratio
- Lower `minZoom` from 4.8 to 3 so wide viewports can zoom out enough to show the entire UK vertically
- Add 20px padding around the bounds for breathing room

Closes #1

## Test plan

- [ ] Open the landing page in a wide viewport (e.g. ultrawide monitor) — the full UK should be visible without vertical scrolling
- [ ] Open in a narrow/tall viewport — the UK should still fit correctly
- [ ] Resize the browser window and refresh — the map should adapt to any aspect ratio
- [ ] Verify zoom controls still work and panning is still constrained to the UK area
- [ ] Verify hover interactions on map areas still function correctly

https://claude.ai/code/session_01VoGKeBLy3Dv2MVozmtXExq