### PR TITLE
Dynamically fit UK bounds on load and window resize

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -904,11 +904,23 @@
                         { id: 'labels', type: 'raster', source: 'carto-labels' },
                     ],
                 },
-                bounds: [[-8.5, 49.8], [2.0, 61.0]],
-                fitBoundsOptions: { padding: 20 },
+                center: [-3.5, 55.5],
+                zoom: 4.8,
                 minZoom: 3,
                 maxBounds: [[-14, 47], [6, 63]],
                 attributionControl: true,
+            });
+
+            // Fit UK bounds to viewport on load and on resize
+            const UK_BOUNDS = [[-8.5, 49.8], [2.0, 61.0]];
+            state.landingMap.on('load', () => {
+                state.landingMap.fitBounds(UK_BOUNDS, { padding: 20, duration: 0 });
+            });
+            window.addEventListener('resize', () => {
+                if (state.landingMap && !el.landingView.classList.contains('hidden')) {
+                    state.landingMap.resize();
+                    state.landingMap.fitBounds(UK_BOUNDS, { padding: 20, duration: 0 });
+                }
             });
 
             state.landingMap.addControl(new maplibregl.NavigationControl(), 'top-left');
@@ -1297,6 +1309,7 @@
             el.neighborZoneCode.textContent = '—';
 
             state.landingMap.resize();
+            state.landingMap.fitBounds([[-8.5, 49.8], [2.0, 61.0]], { padding: 20, duration: 0 });
         }
 
         // ─── Event Listeners ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The static `bounds` constructor option from PR #6 wasn't sufficient — it calculates the fit only once at construction time and doesn't re-adjust when the window is resized. This replaces it with active `fitBounds()` calls that dynamically recalculate the zoom for any viewport dimensions.

- Call `fitBounds()` on the map's `load` event to fit `[[-8.5, 49.8], [2.0, 61.0]]` (full UK extent) into the current viewport
- Call `fitBounds()` on every `window` `resize` event so the map adapts when the browser is resized
- Call `fitBounds()` in `resetView()` when returning from the comparison view to the landing page
- Keep `minZoom: 3` (lowered from 4.8) so wide viewports can zoom out enough

Closes #1

## Test plan

- [ ] Open the landing page in an ultrawide viewport (e.g. 3840×2160) — the full UK from Cornwall to Shetland should be visible
- [ ] Resize the browser window — the map should dynamically re-fit the UK
- [ ] Click an area, then click reset — the landing map should re-fit the UK bounds
- [ ] Verify zoom controls and panning constraints still work
- [ ] Verify hover interactions on map areas still work

https://claude.ai/code/session_01VoGKeBLy3Dv2MVozmtXExq