### PR TITLE
Remove maxBounds to fix UK clipping on wide viewports

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1246,18 +1246,10 @@
           center: [-3.5, 55.5],
           zoom: 4.8,
           minZoom: 3,
-          maxBounds: [
-            [-14, 47],
-            [6, 63],
-          ],
           attributionControl: true,
         });
 
         // Fit UK bounds to viewport on load and on resize
-        const UK_BOUNDS = [
-          [-8.5, 49.8],
-          [2.0, 61.0],
-        ];
         state.landingMap.on("load", () => {
           state.landingMap.fitBounds(UK_BOUNDS, { padding: 20, duration: 0 });
         });
@@ -1687,13 +1679,7 @@
         el.neighborZoneCode.textContent = "—";
 
         state.landingMap.resize();
-        state.landingMap.fitBounds(
-          [
-            [-8.5, 49.8],
-            [2.0, 61.0],
-          ],
-          { padding: 20, duration: 0 },
-        );
+        state.landingMap.fitBounds(UK_BOUNDS, { padding: 20, duration: 0 });
       }
 
       // ─── Event Listeners ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Remove `maxBounds`** — this was the root cause of the clipping. `maxBounds` enforces an implicit minimum zoom so the viewport never shows area outside the bounds. On wide viewports, this forced the zoom *higher* to fill the 20-degree-wide bounds horizontally, making the UK too tall to fit vertically. This silently overrode all `fitBounds` calls from PRs #6 and #7.
- **Unify UK bounds constants** — remove the local `UK_BOUNDS` that shadowed the global one, and replace the hardcoded bounds in `resetView` with the global `UK_BOUNDS` constant.

`minZoom: 3` remains as the only zoom constraint, preventing excessive zoom-out.

Closes #1

## Test plan

- [ ] Open the landing page on an ultrawide viewport (e.g. 3840x2160) — the full UK from Cornwall to Shetland should be visible without clipping
- [ ] Resize the browser window — the map should dynamically re-fit the UK
- [ ] Click an area, then click reset — the landing map should re-fit the UK
- [ ] Verify zoom controls still work
- [ ] Verify hover interactions on map areas still work

https://claude.ai/code/session_01VoGKeBLy3Dv2MVozmtXExq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoGKeBLy3Dv2MVozmtXExq)_